### PR TITLE
fix: allow ID filter inside MultiFilter

### DIFF
--- a/src/Rule/NoDALFilterByID.php
+++ b/src/Rule/NoDALFilterByID.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Shopware\PhpStan\Rule;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use PHPStan\Rules\RuleErrorBuilder;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 
 /**
  * @implements Rule<New_>
@@ -49,6 +52,11 @@ class NoDALFilterByID implements Rule
         }
 
         if (strtolower($firstArg->value) === 'id') {
+            // Allow when used inside a MultiFilter
+            if ($this->isInsideMultiFilter($node, $scope)) {
+                return [];
+            }
+
             return [
                 RuleErrorBuilder::message('Using "id" directly in EqualsFilter or EqualsAnyFilter is forbidden. Pass the ids directly to the constructor of Criteria or use setIds instead')
                     ->line($node->getLine())
@@ -58,5 +66,54 @@ class NoDALFilterByID implements Rule
         }
 
         return [];
+    }
+    
+    /**
+     * Determine if this node is inside a MultiFilter array argument
+     * 
+     * This method checks if the filter is being created in a context where
+     * it's part of an array passed to a MultiFilter constructor.
+     */
+    private function isInsideMultiFilter(Node $node, Scope $scope): bool
+    {
+        $file = $scope->getFile();
+        $fileContents = file_get_contents($file);
+        
+        // Get positions for this node
+        $nodeStartPos = $node->getStartFilePos();
+        $nodeEndPos = $node->getEndFilePos();
+        
+        // Context before this node
+        $contextBefore = substr($fileContents, 0, $nodeStartPos);
+        
+        // Find MultiFilter constructor call
+        $multiFilterPos = strrpos($contextBefore, 'new MultiFilter');
+        if ($multiFilterPos === false) {
+            return false;
+        }
+        
+        // Find array opening that contains our filter
+        $arrayStartPos = strrpos($contextBefore, '[', $multiFilterPos);
+        if ($arrayStartPos === false) {
+            return false;
+        }
+        
+        // Context after this node
+        $contextAfter = substr($fileContents, $nodeEndPos);
+        
+        // Find array closing
+        $arrayEndPos = strpos($contextAfter, ']');
+        if ($arrayEndPos === false) {
+            return false;
+        }
+        
+        // Now check if there's a MultiFilter::CONNECTION_ constant between multiFilterPos and arrayStartPos
+        $connectionPart = substr($fileContents, $multiFilterPos, $arrayStartPos - $multiFilterPos);
+        if (strpos($connectionPart, 'MultiFilter::CONNECTION_') === false) {
+            return false;
+        }
+        
+        // All checks passed - we're inside a MultiFilter array argument
+        return true;
     }
 }

--- a/tests/Rule/NoDALFilterByIDTest.php
+++ b/tests/Rule/NoDALFilterByIDTest.php
@@ -23,7 +23,7 @@ class NoDALFilterByIDTest extends RuleTestCase
                 <<<EOF
 Using "id" directly in EqualsFilter or EqualsAnyFilter is forbidden. Pass the ids directly to the constructor of Criteria or use setIds instead
 EOF,
-                9,
+                12,
             ],
         ]);
     }

--- a/tests/Rule/fixtures/NoDALFilterByID/criteria.php
+++ b/tests/Rule/fixtures/NoDALFilterByID/criteria.php
@@ -4,6 +4,21 @@ declare(strict_types=1);
 
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 
+// This should trigger an error
 $criteria = new Criteria();
 $criteria->addFilter(new EqualsFilter('id', '12345'));
+
+// This should be allowed (inside MultiFilter)
+$ids = ['1', '2', '3'];
+$criteria->addPostFilter(
+    new MultiFilter(
+        MultiFilter::CONNECTION_OR,
+        [
+            new EqualsAnyFilter('parentId', $ids),
+            new EqualsAnyFilter('id', $ids),
+        ]
+    )
+);


### PR DESCRIPTION
## Summary
- Modify NoDALFilterByID rule to allow using ID filters inside MultiFilter constructs
- Add test case demonstrating the allowed edge case
- Implement detection method to check if a filter is inside a MultiFilter array

## Test plan
- Updated test cases pass
- PHPStan analysis correctly flags direct ID filter usage but allows it in MultiFilter

🤖 Generated with [Claude Code](https://claude.ai/code)