### PR TITLE
feat(rules): add unit tests for internal call rules

### DIFF
--- a/src/Rule/DisallowFunctionsRule.php
+++ b/src/Rule/DisallowFunctionsRule.php
@@ -44,7 +44,7 @@ class DisallowFunctionsRule implements Rule
             return [
                 RuleErrorBuilder::message(\sprintf('Do not use %s function in code.', $name))
                     ->line($node->getLine())
-                    ->identifier('shopware.disallow_functions')
+                    ->identifier('shopware.disallowFunctions')
                     ->build(),
             ];
         }

--- a/src/Rule/InternalClassExtendsRule.php
+++ b/src/Rule/InternalClassExtendsRule.php
@@ -43,7 +43,7 @@ class InternalClassExtendsRule implements Rule
             return [
                 RuleErrorBuilder::message(sprintf('Class %s extends internal class %s. Please refrain from extending classes which are annotated with @internal.', (string) $node->name, $parentClassName))
                     ->line($node->getLine())
-                    ->identifier('shopware.internal.class.extends')
+                    ->identifier('shopware.internalClassExtends')
                     ->build(),
             ];
         }

--- a/src/Rule/InternalFunctionCallRule.php
+++ b/src/Rule/InternalFunctionCallRule.php
@@ -55,7 +55,7 @@ class InternalFunctionCallRule implements Rule
         return [
             RuleErrorBuilder::message(sprintf('Call of internal function %s Please refrain from using functions which are annotated with @internal in the Shopware 6 repository.', $function->getName()))
                 ->line($node->getLine())
-                ->identifier('shopware.internal_function_call')
+                ->identifier('shopware.internalFunctionCall')
                 ->build(),
         ];
     }

--- a/src/Rule/InternalMethodCallRule.php
+++ b/src/Rule/InternalMethodCallRule.php
@@ -63,7 +63,7 @@ class InternalMethodCallRule implements Rule
             if (!NamespaceChecker::arePartOfTheSamePackage($scope->getNamespace(), $methodOwnerNamespace)) {
                 return [
                     RuleErrorBuilder::message(sprintf('Call of internal method %s::%s Please refrain from using methods which are annotated with @internal in the Shopware 6 repository.', $classInfo->getName(), $methodDetails->getName()))
-                        ->identifier('shopware.internal_method_call')
+                        ->identifier('shopware.internalMethodCall')
                         ->build(),
                 ];
             }

--- a/tests/Rule/InternalFunctionCallRuleTest.php
+++ b/tests/Rule/InternalFunctionCallRuleTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Shopware\PhpStan\Rule\InternalFunctionCallRule;
+
+class InternalFunctionCallRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new InternalFunctionCallRule($this->createReflectionProvider());
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/../../phpstan.neon',
+        ];
+    }
+
+    public function testInternalFunctionCallRule(): void
+    {
+        $this->analyse([
+            __DIR__ . '/fixtures/InternalFunctionCallRule/app/Test/case.php',
+            __DIR__ . '/fixtures/InternalFunctionCallRule/internal-function.php',
+        ], [
+            [
+                'Call of internal function Shopware\PhpStan\Tests\Rule\fixtures\InternalFunctionCallRule\internalFunction Please refrain from using functions which are annotated with @internal in the Shopware 6 repository.',
+                9,
+            ],
+        ]);
+    }
+}

--- a/tests/Rule/InternalMethodCallRuleTest.php
+++ b/tests/Rule/InternalMethodCallRuleTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Shopware\PhpStan\Rule\InternalMethodCallRule;
+
+class InternalMethodCallRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new InternalMethodCallRule($this->createReflectionProvider());
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/../../phpstan.neon',
+        ];
+    }
+
+    public function testInternalMethodCallRule(): void
+    {
+        $this->analyse([
+            __DIR__ . '/fixtures/InternalMethodCallRule/app/Test/case.php',
+            __DIR__ . '/fixtures/InternalMethodCallRule/SomeClass.php',
+        ], [
+            [
+                'Call of internal method Shopware\PhpStan\Tests\Rule\fixtures\InternalMethodCallRule\SomeClass::internalMethod Please refrain from using methods which are annotated with @internal in the Shopware 6 repository.',
+                11,
+            ],
+        ]);
+    }
+}

--- a/tests/Rule/fixtures/InternalFunctionCallRule/app/Test/case.php
+++ b/tests/Rule/fixtures/InternalFunctionCallRule/app/Test/case.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\App\Test;
+
+function test()
+{
+    \Shopware\PhpStan\Tests\Rule\fixtures\InternalFunctionCallRule\internalFunction();
+}

--- a/tests/Rule/fixtures/InternalFunctionCallRule/internal-function.php
+++ b/tests/Rule/fixtures/InternalFunctionCallRule/internal-function.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Tests\Rule\fixtures\InternalFunctionCallRule;
+
+/**
+ * @internal
+ */
+function internalFunction(): void {}

--- a/tests/Rule/fixtures/InternalMethodCallRule/SomeClass.php
+++ b/tests/Rule/fixtures/InternalMethodCallRule/SomeClass.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Tests\Rule\fixtures\InternalMethodCallRule;
+
+class SomeClass
+{
+    /**
+     * @internal
+     */
+    public function internalMethod(): void {}
+}

--- a/tests/Rule/fixtures/InternalMethodCallRule/app/Test/case.php
+++ b/tests/Rule/fixtures/InternalMethodCallRule/app/Test/case.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\App;
+
+use Shopware\PhpStan\Tests\Rule\fixtures\InternalMethodCallRule\SomeClass;
+
+function test()
+{
+    (new SomeClass())->internalMethod();
+}


### PR DESCRIPTION
This PR adds unit tests for the `InternalFunctionCallRule` and `InternalMethodCallRule` to ensure they are working as expected.