### PR TITLE
feat(system-config): add rule to enforce salesChannelId with SalesChannelContext

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -18,6 +18,7 @@ rules:
     - Shopware\PhpStan\Rule\ForbidLocalDiskWriteRule
     - Shopware\PhpStan\Rule\BestPractise\PreferRouteEventRule
     - Shopware\PhpStan\Rule\BestPractise\DALDefinitionRule
+    - Shopware\PhpStan\Rule\ForwardSalesChannelContextToSystemConfigServiceRule
 
 services:
     -

--- a/src/Rule/ForwardSalesChannelContextToSystemConfigServiceRule.php
+++ b/src/Rule/ForwardSalesChannelContextToSystemConfigServiceRule.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+
+/**
+ * @implements Rule<MethodCall>
+ */
+class ForwardSalesChannelContextToSystemConfigServiceRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($this->shouldBeSkipped($node, $scope)) {
+            return [];
+        }
+
+        if (!$scope->hasVariableType('context')->yes()) {
+            return [];
+        }
+
+        $contextVar = $scope->getVariableType('context');
+
+        if (!(new ObjectType(SalesChannelContext::class))->isSuperTypeOf($contextVar)->yes()) {
+            return [];
+        }
+
+        if (!isset($node->getArgs()[1])) {
+            return [
+                RuleErrorBuilder::message('SystemConfigService methods expects a salesChannelId as second parameter. When a method gets a SalesChannelContext passed and that parameter is not forwarded to SystemConfigService we should throw an phpstan error')
+                    ->identifier('shopware.forwardSalesChannelContext')
+                    ->build(),
+            ];
+        }
+
+        $salesChannelId = $node->getArgs()[1]->value;
+
+        if ($salesChannelId instanceof MethodCall
+            && $salesChannelId->var instanceof Node\Expr\Variable
+            && $salesChannelId->var->name === 'context'
+            && $salesChannelId->name instanceof Identifier
+            && $salesChannelId->name->name === 'getSalesChannelId'
+        ) {
+            return [];
+        }
+
+        if ($salesChannelId instanceof MethodCall
+            && $salesChannelId->var instanceof MethodCall
+            && $salesChannelId->var->var instanceof Node\Expr\Variable
+            && $salesChannelId->var->var->name === 'context'
+            && $salesChannelId->var->name instanceof Identifier
+            && $salesChannelId->var->name->name === 'getSalesChannel'
+            && $salesChannelId->name instanceof Identifier
+            && $salesChannelId->name->name === 'getId'
+        ) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message('SystemConfigService methods expects a salesChannelId as second parameter. When a method gets a SalesChannelContext passed and that parameter is not forwarded to SystemConfigService we should throw an phpstan error')
+                ->identifier('shopware.forwardSalesChannelContext')
+                ->build(),
+        ];
+    }
+
+    private function shouldBeSkipped(MethodCall $node, Scope $scope): bool
+    {
+        $type = $scope->getType($node->var);
+
+        if (!(new ObjectType(SystemConfigService::class))->isSuperTypeOf($type)->yes()) {
+            return true;
+        }
+
+        if (!$node->name instanceof Node\Identifier) {
+            return true;
+        }
+
+        $methodName = $node->name->toString();
+        if (!in_array($methodName, ['get', 'getString', 'getInt', 'getFloat', 'getBool'], true)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Rule/ForwardSalesChannelContextToSystemConfigServiceRule.php
+++ b/src/Rule/ForwardSalesChannelContextToSystemConfigServiceRule.php
@@ -33,13 +33,17 @@ class ForwardSalesChannelContextToSystemConfigServiceRule implements Rule
             return [];
         }
 
-        if (!$scope->hasVariableType('context')->yes()) {
-            return [];
+        $salesChannelContextVarName = null;
+
+        foreach ($scope->getDefinedVariables() as $variableName) {
+            $variableType = $scope->getVariableType($variableName);
+            if ((new ObjectType(SalesChannelContext::class))->isSuperTypeOf($variableType)->yes()) {
+                $salesChannelContextVarName = $variableName;
+                break;
+            }
         }
 
-        $contextVar = $scope->getVariableType('context');
-
-        if (!(new ObjectType(SalesChannelContext::class))->isSuperTypeOf($contextVar)->yes()) {
+        if ($salesChannelContextVarName === null) {
             return [];
         }
 
@@ -55,7 +59,7 @@ class ForwardSalesChannelContextToSystemConfigServiceRule implements Rule
 
         if ($salesChannelId instanceof MethodCall
             && $salesChannelId->var instanceof Node\Expr\Variable
-            && $salesChannelId->var->name === 'context'
+            && $salesChannelId->var->name === $salesChannelContextVarName
             && $salesChannelId->name instanceof Identifier
             && $salesChannelId->name->name === 'getSalesChannelId'
         ) {
@@ -65,7 +69,7 @@ class ForwardSalesChannelContextToSystemConfigServiceRule implements Rule
         if ($salesChannelId instanceof MethodCall
             && $salesChannelId->var instanceof MethodCall
             && $salesChannelId->var->var instanceof Node\Expr\Variable
-            && $salesChannelId->var->var->name === 'context'
+            && $salesChannelId->var->var->name === $salesChannelContextVarName
             && $salesChannelId->var->name instanceof Identifier
             && $salesChannelId->var->name->name === 'getSalesChannel'
             && $salesChannelId->name instanceof Identifier

--- a/tests/Rule/ForwardSalesChannelContextToSystemConfigServiceRuleTest.php
+++ b/tests/Rule/ForwardSalesChannelContextToSystemConfigServiceRuleTest.php
@@ -19,14 +19,6 @@ class ForwardSalesChannelContextToSystemConfigServiceRuleTest extends RuleTestCa
         $this->analyse([__DIR__ . '/fixtures/ForwardSalesChannelContextToSystemConfigServiceRule/wrong-usage.php'], [
             [
                 'SystemConfigService methods expects a salesChannelId as second parameter. When a method gets a SalesChannelContext passed and that parameter is not forwarded to SystemConfigService we should throw an phpstan error',
-                19,
-            ],
-            [
-                'SystemConfigService methods expects a salesChannelId as second parameter. When a method gets a SalesChannelContext passed and that parameter is not forwarded to SystemConfigService we should throw an phpstan error',
-                20,
-            ],
-            [
-                'SystemConfigService methods expects a salesChannelId as second parameter. When a method gets a SalesChannelContext passed and that parameter is not forwarded to SystemConfigService we should throw an phpstan error',
                 21,
             ],
             [
@@ -36,6 +28,14 @@ class ForwardSalesChannelContextToSystemConfigServiceRuleTest extends RuleTestCa
             [
                 'SystemConfigService methods expects a salesChannelId as second parameter. When a method gets a SalesChannelContext passed and that parameter is not forwarded to SystemConfigService we should throw an phpstan error',
                 23,
+            ],
+            [
+                'SystemConfigService methods expects a salesChannelId as second parameter. When a method gets a SalesChannelContext passed and that parameter is not forwarded to SystemConfigService we should throw an phpstan error',
+                24,
+            ],
+            [
+                'SystemConfigService methods expects a salesChannelId as second parameter. When a method gets a SalesChannelContext passed and that parameter is not forwarded to SystemConfigService we should throw an phpstan error',
+                25,
             ],
         ]);
     }

--- a/tests/Rule/ForwardSalesChannelContextToSystemConfigServiceRuleTest.php
+++ b/tests/Rule/ForwardSalesChannelContextToSystemConfigServiceRuleTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Shopware\PhpStan\Rule\ForwardSalesChannelContextToSystemConfigServiceRule;
+
+/**
+ * @extends RuleTestCase<ForwardSalesChannelContextToSystemConfigServiceRule>
+ */
+class ForwardSalesChannelContextToSystemConfigServiceRuleTest extends RuleTestCase
+{
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/fixtures/ForwardSalesChannelContextToSystemConfigServiceRule/correct-usage.php'], []);
+        $this->analyse([__DIR__ . '/fixtures/ForwardSalesChannelContextToSystemConfigServiceRule/wrong-usage.php'], [
+            [
+                'SystemConfigService methods expects a salesChannelId as second parameter. When a method gets a SalesChannelContext passed and that parameter is not forwarded to SystemConfigService we should throw an phpstan error',
+                19,
+            ],
+            [
+                'SystemConfigService methods expects a salesChannelId as second parameter. When a method gets a SalesChannelContext passed and that parameter is not forwarded to SystemConfigService we should throw an phpstan error',
+                20,
+            ],
+            [
+                'SystemConfigService methods expects a salesChannelId as second parameter. When a method gets a SalesChannelContext passed and that parameter is not forwarded to SystemConfigService we should throw an phpstan error',
+                21,
+            ],
+            [
+                'SystemConfigService methods expects a salesChannelId as second parameter. When a method gets a SalesChannelContext passed and that parameter is not forwarded to SystemConfigService we should throw an phpstan error',
+                22,
+            ],
+            [
+                'SystemConfigService methods expects a salesChannelId as second parameter. When a method gets a SalesChannelContext passed and that parameter is not forwarded to SystemConfigService we should throw an phpstan error',
+                23,
+            ],
+        ]);
+    }
+
+    protected function getRule(): Rule
+    {
+        return new ForwardSalesChannelContextToSystemConfigServiceRule($this->createReflectionProvider());
+    }
+}

--- a/tests/Rule/fixtures/ForwardSalesChannelContextToSystemConfigServiceRule/correct-usage.php
+++ b/tests/Rule/fixtures/ForwardSalesChannelContextToSystemConfigServiceRule/correct-usage.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Tests\Rule\fixtures\ForwardSalesChannelContextToSystemConfigServiceRule;
+
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+
+class CorrectUsage
+{
+    private SystemConfigService $systemConfigService;
+
+    public function __construct(SystemConfigService $systemConfigService)
+    {
+        $this->systemConfigService = $systemConfigService;
+    }
+
+    public function correct(SalesChannelContext $context): void
+    {
+        $this->systemConfigService->get('foo.bar', $context->getSalesChannelId());
+        $this->systemConfigService->getString('foo.bar', $context->getSalesChannel()->getId());
+        $this->systemConfigService->getInt('foo.bar', $context->getSalesChannelId());
+        $this->systemConfigService->getFloat('foo.bar', $context->getSalesChannelId());
+        $this->systemConfigService->getBool('foo.bar', $context->getSalesChannelId());
+    }
+
+    public function correctWithoutContext(): void
+    {
+        $this->systemConfigService->get('foo.bar');
+    }
+}

--- a/tests/Rule/fixtures/ForwardSalesChannelContextToSystemConfigServiceRule/correct-usage.php
+++ b/tests/Rule/fixtures/ForwardSalesChannelContextToSystemConfigServiceRule/correct-usage.php
@@ -16,13 +16,13 @@ class CorrectUsage
         $this->systemConfigService = $systemConfigService;
     }
 
-    public function correct(SalesChannelContext $context): void
+    public function correct(SalesChannelContext $salesChannelContext): void
     {
-        $this->systemConfigService->get('foo.bar', $context->getSalesChannelId());
-        $this->systemConfigService->getString('foo.bar', $context->getSalesChannel()->getId());
-        $this->systemConfigService->getInt('foo.bar', $context->getSalesChannelId());
-        $this->systemConfigService->getFloat('foo.bar', $context->getSalesChannelId());
-        $this->systemConfigService->getBool('foo.bar', $context->getSalesChannelId());
+        $this->systemConfigService->get('foo.bar', $salesChannelContext->getSalesChannelId());
+        $this->systemConfigService->getString('foo.bar', $salesChannelContext->getSalesChannel()->getId());
+        $this->systemConfigService->getInt('foo.bar', $salesChannelContext->getSalesChannelId());
+        $this->systemConfigService->getFloat('foo.bar', $salesChannelContext->getSalesChannelId());
+        $this->systemConfigService->getBool('foo.bar', $salesChannelContext->getSalesChannelId());
     }
 
     public function correctWithoutContext(): void

--- a/tests/Rule/fixtures/ForwardSalesChannelContextToSystemConfigServiceRule/wrong-usage.php
+++ b/tests/Rule/fixtures/ForwardSalesChannelContextToSystemConfigServiceRule/wrong-usage.php
@@ -16,7 +16,7 @@ class WrongUsage
         $this->systemConfigService = $systemConfigService;
     }
 
-    public function wrong(SalesChannelContext $context): void
+    public function wrong(SalesChannelContext $salesChannelContext): void
     {
         $this->systemConfigService->get('foo.bar');
         $this->systemConfigService->getString('foo.bar');

--- a/tests/Rule/fixtures/ForwardSalesChannelContextToSystemConfigServiceRule/wrong-usage.php
+++ b/tests/Rule/fixtures/ForwardSalesChannelContextToSystemConfigServiceRule/wrong-usage.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Tests\Rule\fixtures\ForwardSalesChannelContextToSystemConfigServiceRule;
+
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+
+class WrongUsage
+{
+    private SystemConfigService $systemConfigService;
+
+    public function __construct(SystemConfigService $systemConfigService)
+    {
+        $this->systemConfigService = $systemConfigService;
+    }
+
+    public function wrong(SalesChannelContext $context): void
+    {
+        $this->systemConfigService->get('foo.bar');
+        $this->systemConfigService->getString('foo.bar');
+        $this->systemConfigService->getInt('foo.bar');
+        $this->systemConfigService->getFloat('foo.bar');
+        $this->systemConfigService->getBool('foo.bar');
+    }
+}


### PR DESCRIPTION
This PR introduces a new PHPStan rule that ensures the salesChannelId is passed to SystemConfigService methods when a SalesChannelContext is available.