### PR TITLE
feat(rule): disallow session_write_close() usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "symfony/polyfill-php84": "*"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "v3.64.0",
+    "friendsofphp/php-cs-fixer": "v3.84.0",
     "phpstan/extension-installer": "*",
     "phpunit/phpunit": "~11.3.6",
     "shopware/core": "^6.6"

--- a/rules.neon
+++ b/rules.neon
@@ -2,6 +2,7 @@ rules:
     - Shopware\PhpStan\Rule\ClassExtendUsesAbstractClassWhenExisting
     - Shopware\PhpStan\Rule\DisallowDefaultContextCreation
     - Shopware\PhpStan\Rule\DisallowFunctionsRule
+    - Shopware\PhpStan\Rule\DisallowSessionWriteCloseRule
     - Shopware\PhpStan\Rule\ForbidGlobBraceRule
     - Shopware\PhpStan\Rule\InternalClassExtendsRule
     - Shopware\PhpStan\Rule\InternalFunctionCallRule

--- a/src/Rule/DisallowSessionWriteCloseRule.php
+++ b/src/Rule/DisallowSessionWriteCloseRule.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<FuncCall>
+ */
+class DisallowSessionWriteCloseRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return FuncCall::class;
+    }
+
+    /**
+     * @return array<array-key, RuleError|string>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Node\Name) {
+            return [];
+        }
+
+        $name = $node->name->toString();
+
+        if ($name === 'session_write_close') {
+            return [
+                RuleErrorBuilder::message('Do not use session_write_close() function in code. Use $request->getSession()->save() instead.')
+                    ->line($node->getLine())
+                    ->identifier('shopware.disallowSessionWriteClose')
+                    ->build(),
+            ];
+        }
+
+        return [];
+    }
+}

--- a/tests/Rule/DisallowSessionWriteCloseRuleTest.php
+++ b/tests/Rule/DisallowSessionWriteCloseRuleTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Shopware\PhpStan\Rule\DisallowSessionWriteCloseRule;
+
+/**
+ * @extends RuleTestCase<DisallowSessionWriteCloseRule>
+ */
+class DisallowSessionWriteCloseRuleTest extends RuleTestCase
+{
+    public function getRule(): Rule
+    {
+        return new DisallowSessionWriteCloseRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([
+            __DIR__ . '/fixtures/DisallowSessionWriteCloseRule/wrong-usage.php'
+        ], [
+            [
+                'Do not use session_write_close() function in code. Use $request->getSession()->save() instead.',
+                3
+            ]
+        ]);
+    }
+}

--- a/tests/Rule/fixtures/DisallowSessionWriteCloseRule/wrong-usage.php
+++ b/tests/Rule/fixtures/DisallowSessionWriteCloseRule/wrong-usage.php
@@ -1,0 +1,3 @@
+<?php
+
+session_write_close();


### PR DESCRIPTION
This commit introduces a new PHPStan rule to disallow the usage of the `session_write_close()` function. Instead, developers should use `$request->getSession()->save()` from Symfony's HttpFoundation component.

This change enforces a more consistent and framework-aligned approach to session management within the Shopware ecosystem.
