### PR TITLE
fix: handle ChildrenAssociationField with self::class reference

### DIFF
--- a/src/Collector/DALDefinitionCollector.php
+++ b/src/Collector/DALDefinitionCollector.php
@@ -144,6 +144,9 @@ class DALDefinitionCollector implements Collector
         if ($class->is(BreadcrumbField::class)) {
             return 'breadcrumb';
         }
+        if ($class->is(ChildrenAssociationField::class)) {
+            return 'children';
+        }
 
         $args = $newInstance->getArgs();
         if (empty($args)) {
@@ -184,11 +187,6 @@ class DALDefinitionCollector implements Collector
             isset($args[0]) &&
             property_exists($args[0]->value, 'value')
         ) {
-
-            if ($class->is(ChildrenAssociationField::class)) {
-                return 'children';
-            }
-
             if ($args[0]->value instanceof \PhpParser\Node\Scalar\String_) {
                 return $args[0]->value->value;
             }

--- a/tests/Rule/BestPractise/DALDefinitionRuleTest.php
+++ b/tests/Rule/BestPractise/DALDefinitionRuleTest.php
@@ -53,4 +53,9 @@ class DALDefinitionRuleTest extends \PHPStan\Testing\RuleTestCase
     {
         $this->analyse([__DIR__ . '/fixtures/DALDefinitionRule/public-property.php'], []);
     }
+
+    public function testChildrenAssociationFieldWithSelfClass(): void
+    {
+        $this->analyse([__DIR__ . '/fixtures/DALDefinitionRule/children-association-self-class.php'], []);
+    }
 }

--- a/tests/Rule/BestPractise/fixtures/DALDefinitionRule/children-association-self-class.php
+++ b/tests/Rule/BestPractise/fixtures/DALDefinitionRule/children-association-self-class.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Rule\BestPractise\fixtures\DALDefinitionRule;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ChildrenAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+class TreeDefinition extends EntityDefinition
+{
+    public function getEntityName(): string
+    {
+        return 'tree';
+    }
+
+    public function getEntityClass(): string
+    {
+        return TreeEntity::class;
+    }
+
+    public function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
+            new ChildrenAssociationField(self::class),
+        ]);
+    }
+}
+
+class TreeEntity extends Entity
+{
+    use EntityIdTrait;
+
+    public ?TreeCollection $children = null;
+}


### PR DESCRIPTION
## Summary
- `DALDefinitionCollector` threw `RuntimeException: Cannot handle field ...ChildrenAssociationField with arguments [...]` when an entity definition used `new ChildrenAssociationField(self::class)` (or any non-string reference argument).
- Root cause: the collector tried to derive the field's property name from the constructor's first arg, but `ChildrenAssociationField`'s property name is always `'children'` (default), and `self::class` is a `ClassConstFetch` node without a `value` property — so it fell through to the generic branch and blew up.
- Fix: hoist the `ChildrenAssociationField` check into the early special-case block alongside `ChildCountField`, `ParentAssociationField`, etc. The unreachable inner branch was removed.

## Test plan
- [x] Added regression fixture `children-association-self-class.php` exercising `new ChildrenAssociationField(self::class)`
- [x] Verified the fixture reproduces the original error without the fix
- [x] `vendor/bin/phpunit tests/Rule/BestPractise/DALDefinitionRuleTest.php` — all 4 tests pass