### PR TITLE
fix: fix ChildrenAssociationField without propertyName parameter

### DIFF
--- a/src/Collector/DALDefinitionCollector.php
+++ b/src/Collector/DALDefinitionCollector.php
@@ -184,16 +184,15 @@ class DALDefinitionCollector implements Collector
             isset($args[0]) &&
             property_exists($args[0]->value, 'value')
         ) {
-
-            if ($class->is(ChildrenAssociationField::class)) {
-                return 'children';
-            }
-
             if ($args[0]->value instanceof \PhpParser\Node\Scalar\String_) {
                 return $args[0]->value->value;
             }
 
             throw new \RuntimeException(sprintf("Cannot handle field %s with argument of type %s and value %s", $class->getName(), get_class($args[0]->value), json_encode($args[0]->value->value)));
+        }
+
+        if ($class->is(ChildrenAssociationField::class) && !isset($args[1])) {
+            return 'children';
         }
 
         if (isset($args[1]) && $args[1]->value instanceof \PhpParser\Node\Scalar\String_) {

--- a/tests/Rule/BestPractise/DALDefinitionRuleTest.php
+++ b/tests/Rule/BestPractise/DALDefinitionRuleTest.php
@@ -53,4 +53,18 @@ class DALDefinitionRuleTest extends \PHPStan\Testing\RuleTestCase
     {
         $this->analyse([__DIR__ . '/fixtures/DALDefinitionRule/public-property.php'], []);
     }
+
+    public function testChildrenAssociationField(): void
+    {
+        $this->analyse([__DIR__ . '/fixtures/DALDefinitionRule/children-association-field.php'], [
+            [
+                'The field "children" in the definition "tree" is not defined in the entity "Shopware\Tests\Rule\BestPractise\fixtures\DALDefinitionRule\TreeEntity".',
+                1,
+            ],
+            [
+                'The field "customChildren" in the definition "tree" is not defined in the entity "Shopware\Tests\Rule\BestPractise\fixtures\DALDefinitionRule\TreeEntity".',
+                1,
+            ],
+        ]);
+    }
 }

--- a/tests/Rule/BestPractise/fixtures/DALDefinitionRule/children-association-field.php
+++ b/tests/Rule/BestPractise/fixtures/DALDefinitionRule/children-association-field.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Rule\BestPractise\fixtures\DALDefinitionRule;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ChildrenAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+class TreeDefinition extends EntityDefinition
+{
+    public function getEntityName(): string
+    {
+        return 'tree';
+    }
+
+    public function getEntityClass(): string
+    {
+        return TreeEntity::class;
+    }
+
+    public function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
+            new ChildrenAssociationField(self::class),
+            new ChildrenAssociationField(self::class, 'customChildren'),
+        ]);
+    }
+}
+
+class TreeEntity extends Entity
+{
+    use EntityIdTrait;
+}


### PR DESCRIPTION
- fixes shopware/shopware-cli#971