### PR TITLE
fix: support named arguments and fluent builder in ForbidInsecureSymfonyCookieRule

### DIFF
--- a/src/Rule/ForbidInsecureSymfonyCookieRule.php
+++ b/src/Rule/ForbidInsecureSymfonyCookieRule.php
@@ -29,6 +29,8 @@ class ForbidInsecureSymfonyCookieRule implements Rule
 
     private const SECURE_PARAM_INDEX = 5;
 
+    private const ATTR_SECURE_CHECKED_BY_WITHSECURE = 'shopware.secureCookieCheckedByWithSecure';
+
     public function getNodeType(): string
     {
         return Expr::class;
@@ -67,6 +69,12 @@ class ForbidInsecureSymfonyCookieRule implements Rule
             return [];
         }
 
+        // If the parent MethodCall (withSecure) already handles the secure flag,
+        // suppress the error for this node.
+        if ($node->getAttribute(self::ATTR_SECURE_CHECKED_BY_WITHSECURE) === true) {
+            return [];
+        }
+
         return $this->checkSecureParam($node->getArgs(), $node);
     }
 
@@ -88,6 +96,12 @@ class ForbidInsecureSymfonyCookieRule implements Rule
         }
 
         if ($node->name->name !== 'create') {
+            return [];
+        }
+
+        // If the parent MethodCall (withSecure) already handles the secure flag,
+        // suppress the error for this node.
+        if ($node->getAttribute(self::ATTR_SECURE_CHECKED_BY_WITHSECURE) === true) {
             return [];
         }
 
@@ -115,6 +129,10 @@ class ForbidInsecureSymfonyCookieRule implements Rule
 
         $args = $node->getArgs();
 
+        // Mark the var so the constructor/create() call does not emit a
+        // duplicate error – the withSecure() call is the authoritative check.
+        $this->markVarAsSecureChecked($node);
+
         // withSecure() with no args defaults to true
         if (!isset($args[0])) {
             return [];
@@ -135,16 +153,54 @@ class ForbidInsecureSymfonyCookieRule implements Rule
      */
     private function checkSecureParam(array $args, Node $node): array
     {
-        if (!isset($args[self::SECURE_PARAM_INDEX])) {
+        $secureArg = $this->findSecureArg($args);
+
+        if ($secureArg === null) {
             return $this->buildError($node);
         }
 
-        $secureArg = $args[self::SECURE_PARAM_INDEX]->value;
-        if ($secureArg instanceof ConstFetch && $secureArg->name->toLowerString() === 'true') {
+        if ($secureArg->value instanceof ConstFetch && $secureArg->value->name->toLowerString() === 'true') {
             return [];
         }
 
         return $this->buildError($node);
+    }
+
+    /**
+     * @param array<Arg> $args
+     */
+    private function findSecureArg(array $args): ?Arg
+    {
+        $hasNamedArgs = false;
+
+        foreach ($args as $arg) {
+            if ($arg->name !== null) {
+                $hasNamedArgs = true;
+
+                if ($arg->name->name === 'secure') {
+                    return $arg;
+                }
+            }
+        }
+
+        if ($hasNamedArgs) {
+            // Named args are used but 'secure' was not among them
+            return null;
+        }
+
+        // No named args at all – use positional lookup
+        if (!isset($args[self::SECURE_PARAM_INDEX])) {
+            return null;
+        }
+
+        return $args[self::SECURE_PARAM_INDEX];
+    }
+
+    private function markVarAsSecureChecked(MethodCall $node): void
+    {
+        if ($node->var instanceof New_ || $node->var instanceof StaticCall) {
+            $node->var->setAttribute(self::ATTR_SECURE_CHECKED_BY_WITHSECURE, true);
+        }
     }
 
     /**

--- a/tests/Rule/ForbidInsecureSymfonyCookieRuleTest.php
+++ b/tests/Rule/ForbidInsecureSymfonyCookieRuleTest.php
@@ -46,6 +46,22 @@ class ForbidInsecureSymfonyCookieRuleTest extends RuleTestCase
                 'Symfony Cookie created without explicit secure flag. Use the $secure parameter set to true for HTTPS-only transmission.',
                 39,
             ],
+            [
+                'Symfony Cookie created without explicit secure flag. Use the $secure parameter set to true for HTTPS-only transmission.',
+                45,
+            ],
+            [
+                'Symfony Cookie created without explicit secure flag. Use the $secure parameter set to true for HTTPS-only transmission.',
+                51,
+            ],
+            [
+                'Symfony Cookie created without explicit secure flag. Use the $secure parameter set to true for HTTPS-only transmission.',
+                57,
+            ],
+            [
+                'Symfony Cookie created without explicit secure flag. Use the $secure parameter set to true for HTTPS-only transmission.',
+                63,
+            ],
         ]);
     }
 }

--- a/tests/Rule/fixtures/ForbidInsecureSymfonyCookieRule/correct-usage.php
+++ b/tests/Rule/fixtures/ForbidInsecureSymfonyCookieRule/correct-usage.php
@@ -29,4 +29,34 @@ class CorrectUsage
         $cookie = new Cookie('session', 'abc123', 0, '/', '', true);
         $cookie->withSecure();
     }
+
+    // Named arguments
+    public function newCookieWithNamedArgsSecureTrue(): void
+    {
+        new Cookie(name: 'session', secure: true);
+    }
+
+    // Fluent builder – create() + withSecure(true)
+    public function cookieCreateFluentWithSecureTrue(): void
+    {
+        Cookie::create('session')->withSecure(true);
+    }
+
+    // Fluent builder – create() + withSecure() default
+    public function cookieCreateFluentWithSecureDefault(): void
+    {
+        Cookie::create('session')->withSecure();
+    }
+
+    // Fluent builder – new Cookie + withSecure(true)
+    public function newCookieFluentWithSecureTrue(): void
+    {
+        (new Cookie('session'))->withSecure(true);
+    }
+
+    // Fluent builder – new Cookie + withSecure() default
+    public function newCookieFluentWithSecureDefault(): void
+    {
+        (new Cookie('session'))->withSecure();
+    }
 }

--- a/tests/Rule/fixtures/ForbidInsecureSymfonyCookieRule/wrong-usage.php
+++ b/tests/Rule/fixtures/ForbidInsecureSymfonyCookieRule/wrong-usage.php
@@ -38,4 +38,28 @@ class WrongUsage
         $cookie = new Cookie('session', 'abc123', 0, '/', '', true);
         $cookie->withSecure(false);
     }
+
+    // Named arguments – secure not provided
+    public function newCookieNamedArgsWithoutSecure(): void
+    {
+        new Cookie(name: 'session', value: 'abc123');
+    }
+
+    // Named arguments – secure set to false
+    public function newCookieNamedArgsWithSecureFalse(): void
+    {
+        new Cookie(name: 'session', secure: false);
+    }
+
+    // Fluent builder – create() + withSecure(false)
+    public function cookieCreateFluentWithSecureFalse(): void
+    {
+        Cookie::create('session')->withSecure(false);
+    }
+
+    // Fluent builder – new Cookie + withSecure(false)
+    public function newCookieFluentWithSecureFalse(): void
+    {
+        (new Cookie('session'))->withSecure(false);
+    }
 }


### PR DESCRIPTION
## Problem

The `ForbidInsecureSymfonyCookieRule` checks the `secure` argument by positional index (`$args[5]`), which causes two false positives:

1. **Named arguments**: `new Cookie(name: 'x', secure: true)` is falsely flagged because PhpParser stores named args in source order, not at their parameter position. The `secure` arg at index 5 doesn't exist when named args are used.

2. **Fluent builder**: `Cookie::create('x')->withSecure(true)` fails because the `create()` StaticCall is evaluated independently and has no argument at index 5, making it impossible to satisfy the rule without falling back to fully positional arguments.

## Fix

1. **Named arguments** — Added `findSecureArg()` that detects when named arguments are present and searches for `secure` by name instead of positional index. Falls back to positional lookup when no named args are used.

2. **Fluent builder** — When a `withSecure()` call is chained onto a `Cookie::create()` or `new Cookie()`, the constructor/create call's error is suppressed since the `withSecure()` call is the authoritative check. This works because PHPStan processes the parent `MethodCall` before its child `StaticCall`/`New_`.

## Test cases added

**correct-usage.php** — 6 new cases:
- Named args with `secure: true`
- `Cookie::create()->withSecure(true)`
- `Cookie::create()->withSecure()`
- `(new Cookie())->withSecure(true)`
- `(new Cookie())->withSecure()`

**wrong-usage.php** — 4 new cases:
- Named args without `secure`
- Named args with `secure: false`
- `Cookie::create()->withSecure(false)`
- `(new Cookie())->withSecure(false)`