### PR TITLE
fix: prevent error with namespaced function in same namespaced class

### DIFF
--- a/src/Rule/InternalFunctionCallRule.php
+++ b/src/Rule/InternalFunctionCallRule.php
@@ -39,7 +39,7 @@ class InternalFunctionCallRule implements Rule
             return [];
         }
 
-        $function = $this->reflectionProvider->getFunction($node->name, null);
+        $function = $this->reflectionProvider->getFunction($node->name, $scope);
         if (!$function->isInternal()->yes()) {
             return [];
         }

--- a/tests/Rule/InternalFunctionCallRuleTest.php
+++ b/tests/Rule/InternalFunctionCallRuleTest.php
@@ -26,6 +26,7 @@ class InternalFunctionCallRuleTest extends RuleTestCase
     {
         $this->analyse([
             __DIR__ . '/fixtures/InternalFunctionCallRule/app/Test/case.php',
+            __DIR__ . '/fixtures/InternalFunctionCallRule/TestCaseClassWithoutError.php',
             __DIR__ . '/fixtures/InternalFunctionCallRule/internal-function.php',
         ], [
             [

--- a/tests/Rule/fixtures/InternalFunctionCallRule/TestCaseClassWithoutError.php
+++ b/tests/Rule/fixtures/InternalFunctionCallRule/TestCaseClassWithoutError.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\PhpStan\Tests\Rule\fixtures\InternalFunctionCallRule;
+
+class TestCaseClassWithoutError
+{
+    public function something(): void
+    {
+        internalFunction();
+    }
+}


### PR DESCRIPTION
PHPStan crashes when calling a namespaced function (without fully qualified name) in a class within the same namespace.
This happens because of `InternalFunctionCallRule` cannot find the function without the namespace/scope info. 

This error can occur when using symfony service container PHP definitions. 

I added a smaller similar case to the existing test.