### PR TITLE
fix: allow nested DAL ID filters

### DIFF
--- a/src/Rule/NoDALFilterByID.php
+++ b/src/Rule/NoDALFilterByID.php
@@ -5,72 +5,51 @@ declare(strict_types=1);
 namespace Shopware\PhpStan\Rule;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\New_;
-use PhpParser\NodeFinder;
+use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use PHPStan\Rules\RuleErrorBuilder;
 
 /**
- * @implements Rule<New_>
+ * @implements Rule<MethodCall>
  */
 class NoDALFilterByID implements Rule
 {
     public function getNodeType(): string
     {
-        return New_::class;
+        return MethodCall::class;
     }
 
     public function processNode(Node $node, Scope $scope): array
     {
-        if (!$node->class instanceof Node\Name) {
+        if (!$node->name instanceof Node\Identifier || $node->name->toString() !== 'addFilter') {
             return [];
         }
 
-        $className = $node->class->toString();
-
-        // When we find a MultiFilter/NotFilter, mark all nested New_ nodes as allowed
-        if (in_array($className, [MultiFilter::class, NotFilter::class], true)) {
-            $this->markNestedNodesAsAllowed($node);
+        if (!$scope->getType($node->var)->isInstanceOf(Criteria::class)->yes()) {
             return [];
         }
 
-        // Check direct EqualsFilter/EqualsAnyFilter usage
-        if (in_array($className, [EqualsFilter::class, EqualsAnyFilter::class], true)) {
-            return $this->checkFilterNode($node, $scope);
+        if (!isset($node->args[0]) || !$node->args[0]->value instanceof Node\Expr\New_) {
+            return [];
         }
 
-        return [];
-    }
-
-    private function markNestedNodesAsAllowed(Node $allowedFilterNode): void
-    {
-        $nodeFinder = new NodeFinder();
-
-        // Find all New_ nodes within this allowed filter node
-        $nestedNewNodes = $nodeFinder->findInstanceOf($allowedFilterNode, New_::class);
-
-        foreach ($nestedNewNodes as $nestedNode) {
-            // Mark this node as being inside an allowed filter
-            $nestedNode->setAttribute('insideAllowedFilter', true);
-        }
+        return $this->checkFilterNode($node->args[0]->value);
     }
 
     /**
      * @return list<\PHPStan\Rules\IdentifierRuleError>
      */
-    private function checkFilterNode(Node $node, Scope $scope): array
+    private function checkFilterNode(Node\Expr\New_ $node): array
     {
-        // Check if this node is marked as being inside an allowed filter
-        if ($node->getAttribute('insideAllowedFilter') === true) {
+        if (!$node->class instanceof Node\Name) {
             return [];
         }
 
-        if (empty($node->args)) {
+        if (!in_array($node->class->toString(), [EqualsFilter::class, EqualsAnyFilter::class], true) || $node->args === []) {
             return [];
         }
 

--- a/src/Rule/NoDALFilterByID.php
+++ b/src/Rule/NoDALFilterByID.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+use PHPStan\Type\ObjectType;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -29,11 +30,11 @@ class NoDALFilterByID implements Rule
             return [];
         }
 
-        if (!$scope->getType($node->var)->isInstanceOf(Criteria::class)->yes()) {
+        if (!(new ObjectType(Criteria::class))->isSuperTypeOf($scope->getType($node->var))->yes()) {
             return [];
         }
 
-        if (!isset($node->args[0]) || !$node->args[0]->value instanceof Node\Expr\New_) {
+        if (!isset($node->args[0]) || !$node->args[0] instanceof Node\Arg || !$node->args[0]->value instanceof Node\Expr\New_) {
             return [];
         }
 
@@ -53,17 +54,11 @@ class NoDALFilterByID implements Rule
             return [];
         }
 
-        $args = $node->args;
-        if (!is_array($args) || !isset($args[0])) {
+        if (!isset($node->args[0]) || !$node->args[0] instanceof Node\Arg) {
             return [];
         }
 
-        $firstArgNode = $args[0];
-        if (!$firstArgNode instanceof Node\Arg) {
-            return [];
-        }
-
-        $firstArgValue = $firstArgNode->value;
+        $firstArgValue = $node->args[0]->value;
 
         if (!$firstArgValue instanceof Node\Scalar\String_) {
             return [];

--- a/tests/Rule/NoDALFilterByIDTest.php
+++ b/tests/Rule/NoDALFilterByIDTest.php
@@ -6,7 +6,6 @@ namespace Shopware\PhpStan\Tests\Rule;
 
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
-use Shopware\PhpStan\Rule\MethodBecomesAbstractRule;
 use Shopware\PhpStan\Rule\NoDALFilterByID;
 
 /**
@@ -23,7 +22,7 @@ class NoDALFilterByIDTest extends RuleTestCase
                 <<<EOF
 Using "id" directly in EqualsFilter or EqualsAnyFilter is forbidden. Pass the ids directly to the constructor of Criteria or use setIds instead
 EOF,
-                12,
+                13,
             ],
         ]);
     }

--- a/tests/Rule/fixtures/NoDALFilterByID/criteria.php
+++ b/tests/Rule/fixtures/NoDALFilterByID/criteria.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 
 $criteria = new Criteria();
 $criteria->addFilter(new EqualsFilter('id', '12345'));
@@ -26,3 +27,8 @@ $criteria->addFilter(new NotFilter(
         new EqualsAnyFilter('id', ['123', '456']),
     ],
 ));
+
+// This should be allowed when wrapped in any nested filter.
+$criteria->addFilter(new OrFilter([
+    new EqualsAnyFilter('id', ['123', '456']),
+]));


### PR DESCRIPTION
## Summary

Avoid false positives when an ID equality filter is nested in a compound DAL filter.

## Details

- inspect `Criteria::addFilter()` calls instead of every filter instantiation
- report only a direct `EqualsFilter` or `EqualsAnyFilter` on `id`, which can be replaced with `Criteria::setIds()`
- leave nested filters untouched because their composition changes the query semantics
- add coverage for `MultiFilter`, `NotFilter`, and `OrFilter` nesting

## Validation

- `vendor/bin/phpunit tests/Rule/NoDALFilterByIDTest.php`
- `PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run --diff`
