### PR TITLE
fix: detect imported Symfony cookie calls

### DIFF
--- a/src/Rule/ForbidInsecureSymfonyCookieRule.php
+++ b/src/Rule/ForbidInsecureSymfonyCookieRule.php
@@ -42,11 +42,11 @@ class ForbidInsecureSymfonyCookieRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         if ($node instanceof New_) {
-            return $this->processNew($node);
+            return $this->processNew($node, $scope);
         }
 
         if ($node instanceof StaticCall) {
-            return $this->processStaticCall($node);
+            return $this->processStaticCall($node, $scope);
         }
 
         if ($node instanceof MethodCall) {
@@ -59,13 +59,13 @@ class ForbidInsecureSymfonyCookieRule implements Rule
     /**
      * @return list<IdentifierRuleError>
      */
-    private function processNew(New_ $node): array
+    private function processNew(New_ $node, Scope $scope): array
     {
         if (!$node->class instanceof Name) {
             return [];
         }
 
-        if ($node->class->toString() !== self::SYMFONY_COOKIE_CLASS) {
+        if (!$this->isSymfonyCookie($node, $scope)) {
             return [];
         }
 
@@ -81,13 +81,13 @@ class ForbidInsecureSymfonyCookieRule implements Rule
     /**
      * @return list<IdentifierRuleError>
      */
-    private function processStaticCall(StaticCall $node): array
+    private function processStaticCall(StaticCall $node, Scope $scope): array
     {
         if (!$node->class instanceof Name) {
             return [];
         }
 
-        if ($node->class->toString() !== self::SYMFONY_COOKIE_CLASS) {
+        if (!$this->isSymfonyCookie($node, $scope)) {
             return [];
         }
 
@@ -201,6 +201,11 @@ class ForbidInsecureSymfonyCookieRule implements Rule
         if ($node->var instanceof New_ || $node->var instanceof StaticCall) {
             $node->var->setAttribute(self::ATTR_SECURE_CHECKED_BY_WITHSECURE, true);
         }
+    }
+
+    private function isSymfonyCookie(Expr $node, Scope $scope): bool
+    {
+        return (new ObjectType(self::SYMFONY_COOKIE_CLASS))->isSuperTypeOf($scope->getType($node))->yes();
     }
 
     /**


### PR DESCRIPTION
## Summary

Restore detection of insecure Symfony Cookie construction and factory calls that use an imported Cookie class.

## Details

- use PHPStan's inferred expression type to identify Symfony Cookie instances
- retain the existing handling for named arguments and fluent withSecure calls
- make the existing cookie-rule test pass with all ten intended violations

## Validation

- vendor/bin/phpunit tests/Rule/ForbidInsecureSymfonyCookieRuleTest.php
- php -d memory_limit=1G vendor/bin/phpunit
- php -d memory_limit=1G vendor/bin/phpstan analyse src/Rule/ForbidInsecureSymfonyCookieRule.php --no-progress
- PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run --diff