### PR TITLE
fix: allow decorators extending abstract contracts

### DIFF
--- a/src/Rule/ClassExtendUsesAbstractClassWhenExisting.php
+++ b/src/Rule/ClassExtendUsesAbstractClassWhenExisting.php
@@ -45,6 +45,10 @@ class ClassExtendUsesAbstractClassWhenExisting implements Rule
             return [];
         }
 
+        if ($parentClassReflection->isAbstract()) {
+            return [];
+        }
+
         foreach ($parentClassReflection->getParents() as $parent) {
             if ($parent->isAbstract()) {
                 return [

--- a/tests/Rule/fixtures/ClassExtendUsesAbstractClassWhenExisting/extends.php
+++ b/tests/Rule/fixtures/ClassExtendUsesAbstractClassWhenExisting/extends.php
@@ -22,3 +22,13 @@ class Plugin extends Core
         return new Plugin();
     }
 }
+
+abstract class AbstractPluginDecorator extends AbstractCore {}
+
+class PluginDecorator extends AbstractPluginDecorator
+{
+    public function getDecorated(): PluginDecorator
+    {
+        return new PluginDecorator();
+    }
+}


### PR DESCRIPTION
## Summary

Do not report `shopware.class.extends.abstract` when a decorator already extends an abstract contract. The rule only needs to flag decorators extending a concrete implementation that has an abstract parent.

## Test plan

- `vendor/bin/phpunit tests/Rule/ClassExtendUsesAbstractClassWhenExistingTest.php`
- `vendor/bin/php-cs-fixer fix --dry-run --diff`