### PR TITLE
feat: check future property visibility

### DIFF
--- a/src/Rule/FutureCompatibility/FutureCallSiteRule.php
+++ b/src/Rule/FutureCompatibility/FutureCallSiteRule.php
@@ -9,7 +9,9 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\CallLike;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
@@ -23,9 +25,9 @@ use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Type\VerbosityLevel;
 
 /**
- * Reports extension call sites incompatible with a BC-change attribute announced by Core.
+ * Reports extension call sites and property accesses incompatible with a BC-change attribute announced by Core.
  *
- * @implements Rule<CallLike>
+ * @implements Rule<Node>
  * @internal
  */
 final class FutureCallSiteRule implements Rule
@@ -34,6 +36,7 @@ final class FutureCallSiteRule implements Rule
 
     private const METHOD_BECOMES_INTERNAL = 'shopware.futureIncompatibility.methodBecomesInternal';
     private const METHOD_VISIBILITY_CHANGE = 'shopware.futureIncompatibility.methodVisibilityChange';
+    private const PROPERTY_VISIBILITY_CHANGE = 'shopware.futureIncompatibility.propertyVisibilityChange';
     private const PARAMETER_REMOVAL = 'shopware.futureIncompatibility.parameterRemoval';
     private const PARAMETER_NAME_CHANGE = 'shopware.futureIncompatibility.parameterNameChange';
     private const NEW_REQUIRED_PARAMETER = 'shopware.futureIncompatibility.newRequiredParameter';
@@ -48,10 +51,23 @@ final class FutureCallSiteRule implements Rule
 
     public function getNodeType(): string
     {
-        return CallLike::class;
+        return Node::class;
     }
 
     public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node instanceof CallLike) {
+            return $this->processCall($node, $scope);
+        }
+
+        if ($node instanceof PropertyFetch || $node instanceof StaticPropertyFetch) {
+            return $this->processPropertyAccess($node, $scope);
+        }
+
+        return [];
+    }
+
+    private function processCall(CallLike $node, Scope $scope): array
     {
         $methodName = $this->methodName($node);
         if ($methodName === null) {
@@ -128,6 +144,48 @@ final class FutureCallSiteRule implements Rule
         return $errors;
     }
 
+    /**
+     * @return list<IdentifierRuleError>
+     */
+    private function processPropertyAccess(PropertyFetch|StaticPropertyFetch $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Identifier) {
+            return [];
+        }
+
+        $propertyName = $node->name->toString();
+        foreach ($this->propertyClasses($node, $scope) as $class) {
+            $native = $class->getNativeReflection();
+            if (!$native->hasProperty($propertyName)) {
+                continue;
+            }
+
+            $property = $native->getProperty($propertyName);
+            foreach ($property->getAttributes() as $attribute) {
+                if ($attribute->getName() !== self::ATTRIBUTE_NAMESPACE . 'VisibilityChange') {
+                    continue;
+                }
+
+                $arguments = $attribute->getArguments();
+                $version = $this->stringArgument($arguments, 'version', 0);
+                if ($this->isDeprecatedInVersion($scope, $version)) {
+                    continue;
+                }
+
+                $visibility = $arguments['newVisibility'] ?? $arguments[1] ?? null;
+                if ($this->canAccess($visibility, $class, $scope)) {
+                    continue;
+                }
+
+                $symbol = sprintf('%s::$%s', $class->getDisplayName(), $propertyName);
+
+                return [$this->error(sprintf('Property "%s" will become %s in %s. This access will break; stop accessing it from outside that scope.', $symbol, is_string($visibility) ? $visibility : '?', $version), self::PROPERTY_VISIBILITY_CHANGE)];
+            }
+        }
+
+        return [];
+    }
+
     private function methodName(CallLike $node): ?string
     {
         if (($node instanceof MethodCall || $node instanceof StaticCall) && $node->name instanceof Identifier) {
@@ -155,6 +213,24 @@ final class FutureCallSiteRule implements Rule
         }
 
         return null;
+    }
+
+    /**
+     * @return list<ClassReflection>
+     */
+    private function propertyClasses(PropertyFetch|StaticPropertyFetch $node, Scope $scope): array
+    {
+        if ($node instanceof PropertyFetch) {
+            return $scope->getType($node->var)->getObjectClassReflections();
+        }
+
+        if (!$node->class instanceof Name) {
+            return [];
+        }
+
+        $className = $scope->resolveName($node->class);
+
+        return $this->reflectionProvider->hasClass($className) ? [$this->reflectionProvider->getClass($className)] : [];
     }
 
     /**

--- a/tests/Rule/FutureCallSiteRuleTest.php
+++ b/tests/Rule/FutureCallSiteRuleTest.php
@@ -19,17 +19,19 @@ class FutureCallSiteRuleTest extends RuleTestCase
     public function testReportsFutureIncompatibleCallSites(): void
     {
         $this->analyse([__DIR__ . '/fixtures/FutureCallSiteRule/call-site.php'], [
-            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::internalMethod()" will become internal in v6.8.0. Stop calling it to stay compatible.', 49],
-            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::becomesProtected()" will become protected in v6.8.0. This call will break; stop calling it from outside that scope.', 50],
-            ['Parameter $options of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withRemoval()" will be removed in v6.8.0. Stop passing it to stay compatible with both versions.', 51],
-            ['Parameter $options of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withRemoval()" will be removed in v6.8.0. Stop passing it to stay compatible with both versions.', 52],
-            ['Parameter $oldName of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withRename()" will be renamed to $newName in v6.8.0. A named argument cannot be compatible with both versions; pass it positionally.', 55],
-            ['Parameter $id of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withNarrowing()" will be narrowed to string in v6.8.0, but int is passed. Pass string to stay compatible with both versions.', 57],
-            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withNewRequired()" will require a new parameter $context in v6.8.0. Pass it positionally now to stay compatible with both versions.', 58],
-            ['The default value of parameter $strict of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withDefaultValue()" will change in v6.8.0. Pass the current default explicitly to retain current behavior.', 60],
-            ['Class "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\InternalSubject" will become internal in v6.8.0. Stop using it to stay compatible.', 62],
-            ['Class "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\InternalSubject" will become internal in v6.8.0. Stop using it to stay compatible.', 63],
-            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::internalMethod()" will become internal in v6.8.0. Stop calling it to stay compatible.', 100],
+            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::internalMethod()" will become internal in v6.8.0. Stop calling it to stay compatible.', 55],
+            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::becomesProtected()" will become protected in v6.8.0. This call will break; stop calling it from outside that scope.', 56],
+            ['Property "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::$becomesProtectedProperty" will become protected in v6.8.0. This access will break; stop accessing it from outside that scope.', 57],
+            ['Property "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::$becomesPrivateProperty" will become private in v6.8.0. This access will break; stop accessing it from outside that scope.', 58],
+            ['Parameter $options of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withRemoval()" will be removed in v6.8.0. Stop passing it to stay compatible with both versions.', 59],
+            ['Parameter $options of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withRemoval()" will be removed in v6.8.0. Stop passing it to stay compatible with both versions.', 60],
+            ['Parameter $oldName of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withRename()" will be renamed to $newName in v6.8.0. A named argument cannot be compatible with both versions; pass it positionally.', 63],
+            ['Parameter $id of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withNarrowing()" will be narrowed to string in v6.8.0, but int is passed. Pass string to stay compatible with both versions.', 65],
+            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withNewRequired()" will require a new parameter $context in v6.8.0. Pass it positionally now to stay compatible with both versions.', 66],
+            ['The default value of parameter $strict of "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::withDefaultValue()" will change in v6.8.0. Pass the current default explicitly to retain current behavior.', 68],
+            ['Class "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\InternalSubject" will become internal in v6.8.0. Stop using it to stay compatible.', 70],
+            ['Class "Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\InternalSubject" will become internal in v6.8.0. Stop using it to stay compatible.', 71],
+            ['"Shopware\\PhpStan\\Tests\\Fixture\\FutureCallSiteRule\\BCSubject::internalMethod()" will become internal in v6.8.0. Stop calling it to stay compatible.', 109],
         ]);
     }
 

--- a/tests/Rule/fixtures/FutureCallSiteRule/call-site.php
+++ b/tests/Rule/fixtures/FutureCallSiteRule/call-site.php
@@ -14,6 +14,12 @@ use Shopware\Core\Framework\Deprecation\BCChange\VisibilityChange;
 
 class BCSubject
 {
+    #[VisibilityChange(version: 'v6.8.0', newVisibility: 'protected')]
+    public string $becomesProtectedProperty = 'value';
+
+    #[VisibilityChange(version: 'v6.8.0', newVisibility: 'private')]
+    public static string $becomesPrivateProperty = 'value';
+
     #[BecomesInternal(version: 'v6.8.0')]
     public function internalMethod(): void {}
 
@@ -48,6 +54,8 @@ class Caller
     {
         $subject->internalMethod();
         $subject->becomesProtected();
+        $subject->becomesProtectedProperty;
+        BCSubject::$becomesPrivateProperty;
         $subject->withRemoval(['a']);
         $subject->withRemoval(options: ['a']);
         $subject->withRemoval();
@@ -69,6 +77,7 @@ class SubclassCaller extends BCSubject
     public function allowed(): void
     {
         $this->becomesProtected();
+        $this->becomesProtectedProperty;
     }
 }
 


### PR DESCRIPTION
## Summary

- Report property access that will become inaccessible after a VisibilityChange.
- Cover protected and private property changes while allowing access from the declaring class and subclasses.

## Validation

- phpunit tests/Rule/FutureCallSiteRuleTest.php
- php-cs-fixer dry run on the changed files